### PR TITLE
Горленко Алексей (все кроме реализации без БД) 

### DIFF
--- a/src/main/java/com/moneytransfer/dao/AccountDAO.java
+++ b/src/main/java/com/moneytransfer/dao/AccountDAO.java
@@ -5,11 +5,11 @@ import com.moneytransfer.model.Account;
 import com.moneytransfer.model.UserTransaction;
 
 import java.math.BigDecimal;
-import java.util.Set;
+import java.util.List;
 
 public interface AccountDAO {
 
-  Set<Account> getAllAccounts() throws CustomException;
+  List<Account> getAllAccounts() throws CustomException;
 
   Account getAccountById(long accountId) throws CustomException;
 

--- a/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
+++ b/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
@@ -38,12 +38,12 @@ public class H2DAOFactory extends DAOFactory {
 	}
 
 	public UserDAO getUserDAO() {
-		DbUtils.loadDriver(h2_driver);
+		//DbUtils.loadDriver(h2_driver);
 		return new UserDAOImpl();
 	}
 
 	public AccountDAO getAccountDAO() {
-		DbUtils.loadDriver(h2_driver);
+		//DbUtils.loadDriver(h2_driver);
 		return new AccountDAOImpl();
 	}
 

--- a/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
+++ b/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
@@ -39,12 +39,14 @@ public class H2DAOFactory extends DAOFactory {
 
 	public UserDAO getUserDAO() {
 		//DbUtils.loadDriver(h2_driver);
-		return new UserDAOImpl();
+		//return new UserDAOImpl();
+		return userDAO;
 	}
 
 	public AccountDAO getAccountDAO() {
 		//DbUtils.loadDriver(h2_driver);
-		return new AccountDAOImpl();
+		//return new AccountDAOImpl();
+		return accountDAO;
 	}
 
 	@Override

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -17,6 +17,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 public class AccountDAOImpl implements AccountDAO {
 
@@ -32,11 +34,11 @@ public class AccountDAOImpl implements AccountDAO {
   /**
    * Get all accounts.
    */
-  public Set<Account> getAllAccounts() throws CustomException {
+  public List<Account> getAllAccounts() throws CustomException {
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
-    Set<Account> allAccounts = new HashSet<>();
+    List<Account> allAccounts = new ArrayList<>();
     try {
       conn = H2DAOFactory.getConnection();
       stmt = conn.prepareStatement(SQL_GET_ALL_ACC);

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -158,8 +158,8 @@ public class AccountDAOImpl implements AccountDAO {
     } catch (SQLException e) {
       throw new CustomException("deleteAccountById(): Error deleting user account Id " + accountId, e);
     } finally {
+      DbUtils.closeQuietly(stmt);      
       DbUtils.closeQuietly(conn);
-      DbUtils.closeQuietly(stmt);
     }
   }
 
@@ -216,10 +216,10 @@ public class AccountDAOImpl implements AccountDAO {
         throw new CustomException("Fail to rollback transaction", re);
       }
     } finally {
-      DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(rs);
       DbUtils.closeQuietly(lockStmt);
       DbUtils.closeQuietly(updateStmt);
+      DbUtils.closeQuietly(conn);
     }
     return updateCount;
   }
@@ -309,10 +309,10 @@ public class AccountDAOImpl implements AccountDAO {
         throw new CustomException("Fail to rollback transaction", re);
       }
     } finally {
-      DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(rs);
       DbUtils.closeQuietly(lockStmt);
       DbUtils.closeQuietly(updateStmt);
+      DbUtils.closeQuietly(conn);
     }
     return result;
   }

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -15,8 +15,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -103,11 +103,7 @@ public class AccountDAOImpl implements AccountDAO {
           log.debug("Retrieve Account By userId: " + acc);
         }
       }
-      return getAllAccounts()
-          .stream()
-          .filter(account -> account.getUserName().equals(user) && account.getCurrencyCode().equals(currency))
-          .findFirst()
-          .orElse(null);
+      return acc;
     } catch (SQLException e) {
       throw new CustomException("getAccountById(): Error reading account data", e);
     } finally {

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -250,6 +250,10 @@ public class AccountDAOImpl implements AccountDAO {
           log.debug("transferAccountBalance from Account: " + fromAccount);
         }
       }
+      
+      DbUtils.closeQuietly(rs);
+      DbUtils.closeQuietly(lockStmt);
+      
       lockStmt = conn.prepareStatement(SQL_LOCK_ACC_BY_ID);
       lockStmt.setLong(1, userTransaction.getToAccountId());
       rs = lockStmt.executeQuery();

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -43,7 +43,7 @@ public class UserDAOImpl implements UserDAO {
         if (log.isDebugEnabled())
           log.debug("getAllUsers() Retrieve User: " + u);
       }
-      fetched.addAll(users);
+      //fetched.addAll(users);
       return users;
     } catch (SQLException e) {
       throw new CustomException("Error reading user data", e);

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -110,12 +110,13 @@ public class UserDAOImpl implements UserDAO {
   public long insertUser(User user) throws CustomException {
     Connection conn = null;
     PreparedStatement stmt = null;
+    PreparedStatement stmt_max_id = null;
     ResultSet rs = null;
     try {
       conn = H2DAOFactory.getConnection();
       conn.setAutoCommit(false);
-      stmt = conn.prepareStatement(SQL_GET_MAX_USER_ID);
-      rs = stmt.executeQuery();
+      stmt_max_id = conn.prepareStatement(SQL_GET_MAX_USER_ID);
+      rs = stmt_max_id.executeQuery();
       long id = 1;
       if (rs.next()) {
         id = rs.getLong("MaxUserId") + 1;
@@ -137,6 +138,7 @@ public class UserDAOImpl implements UserDAO {
       log.error("Error Inserting User :" + user);
       throw new CustomException("Error creating user data", e);
     } finally {
+      DbUtils.closeQuietly(stmt_max_id);
       DbUtils.closeQuietly(conn, stmt, rs);
     }
 

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -23,7 +23,7 @@ public class UserDAOImpl implements UserDAO {
   private final static String SQL_DELETE_USER_BY_ID = "DELETE FROM User WHERE UserId = ? ";
   private final static String SQL_GET_MAX_USER_ID = "SELECT MAX(UserID) AS MaxUserId FROM User";
   
-  private List<User> fetched = new ArrayList<>();
+  //private List<User> fetched = new ArrayList<>();
 
   /**
    * Find all users

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -137,7 +137,7 @@ public class UserDAOImpl implements UserDAO {
       log.error("Error Inserting User :" + user);
       throw new CustomException("Error creating user data", e);
     } finally {
-      DbUtils.closeQuietly(conn);
+      DbUtils.closeQuietly(conn, stmt, rs);
     }
 
   }
@@ -160,8 +160,8 @@ public class UserDAOImpl implements UserDAO {
       log.error("Error Updating User :" + user);
       throw new CustomException("Error update user data", e);
     } finally {
+      DbUtils.closeQuietly(stmt);      
       DbUtils.closeQuietly(conn);
-      DbUtils.closeQuietly(stmt);
     }
   }
 
@@ -181,8 +181,8 @@ public class UserDAOImpl implements UserDAO {
       log.error("Error Deleting User :" + userId);
       throw new CustomException("Error Deleting User ID:" + userId, e);
     } finally {
-      DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(stmt);
+      DbUtils.closeQuietly(conn);
     }
   }
 }

--- a/src/main/java/com/moneytransfer/model/Account.java
+++ b/src/main/java/com/moneytransfer/model/Account.java
@@ -3,6 +3,7 @@ package com.moneytransfer.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 public class Account {
 
@@ -64,7 +65,12 @@ public class Account {
 
   @Override
   public int hashCode() {
-    return 1;
+    //return Objects.hash(accountId, userName, balance, currencyCode);
+		int result = Long.hashCode(accountId);
+		result = 31 * result + userName.hashCode();
+		result = 31 * result + balance.hashCode();
+		result = 31 * result + currencyCode.hashCode();
+		return result;
   }
 
   @Override

--- a/src/main/java/com/moneytransfer/model/Account.java
+++ b/src/main/java/com/moneytransfer/model/Account.java
@@ -3,7 +3,6 @@ package com.moneytransfer.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
-import java.util.Objects;
 
 public class Account {
 

--- a/src/main/java/com/moneytransfer/service/AccountService.java
+++ b/src/main/java/com/moneytransfer/service/AccountService.java
@@ -13,7 +13,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.util.Set;
+import java.util.List;
 
 /**
  * Account Service
@@ -36,7 +36,7 @@ public class AccountService {
   @GET
   @Path("/all")
   public Response getAllAccounts() throws CustomException {
-    Set<Account> account = daoFactory.getAccountDAO().getAllAccounts();
+    List<Account> account = daoFactory.getAccountDAO().getAllAccounts();
     return Response.ok("[" + account.stream().map(Account::toString).collect(Collectors.joining(",")) + "]").build();
   }
 

--- a/src/main/java/com/moneytransfer/service/UserService.java
+++ b/src/main/java/com/moneytransfer/service/UserService.java
@@ -31,7 +31,7 @@ public class UserService {
 
   private static Logger log = Logger.getLogger(UserService.class);
 
-  private List<User> allUsers = new ArrayList<>();
+  //private List<User> allUsers = new ArrayList<>();
 
   /**
    * Find by userName
@@ -62,7 +62,7 @@ public class UserService {
   @Path("/all")
   public Response getAllUsers() throws CustomException {
     List<User> users = daoFactory.getUserDAO().getAllUsers();
-    allUsers.addAll(users);
+    //allUsers.addAll(users);
     return Response.ok("[" + users.stream().map(User::toString).collect(Collectors.joining(",")) + "]").build();
   }
 

--- a/src/main/java/com/moneytransfer/service/UserService.java
+++ b/src/main/java/com/moneytransfer/service/UserService.java
@@ -3,9 +3,10 @@ package com.moneytransfer.service;
 import com.moneytransfer.dao.DAOFactory;
 import com.moneytransfer.exception.CustomException;
 import com.moneytransfer.model.User;
+
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -124,42 +125,30 @@ public class UserService {
     }
   }
 
-//  static {
-//    InputStream r = UserService.class.getClassLoader().getResourceAsStream("user.jpg");
-//
-//    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-//
-//    int nRead;
-//    byte[] data = new byte[16384];
-//
-//    try {
-//      while ((nRead = r.read(data, 0, data.length)) != -1) {
-//        buffer.write(data, 0, nRead);
-//      }
-//    } catch (Exception e) {}
-//
-//    arr = buffer.toByteArray();
-//  }
+  static {
+    InputStream r = UserService.class.getClassLoader().getResourceAsStream("user.jpg");
 
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    int nRead;
+    byte[] data = new byte[16384];
+
+    try {
+      while ((nRead = r.read(data, 0, data.length)) != -1) {
+        buffer.write(data, 0, nRead);
+      }
+    } catch (Exception e) {}
+
+    arr = buffer.toByteArray();
+  }
+
+  static byte[] arr;
+  
   @GET
   @Path("/{userId}/image")
   @Produces(MediaType.APPLICATION_SVG_XML)
   public Response getUserImage(@PathParam("userId") long userId) throws IOException {
-    InputStream r = UserService.class.getClassLoader().getResourceAsStream("user.jpg");
-
-    byte[] img = new byte[0];
-    int read = r.read();
-    while (read != -1) {
-      byte[] img1 = new byte[img.length+1];
-      for (int i = 0; i < img.length; i++) {
-        img1[i] = img[i];
-      }
-      img1[img1.length-1] = (byte) read;
-      img = img1;
-      read = r.read();
-    }
-
-    return Response.ok(img).header("hash", calcHashImg(img)).build();
+    return Response.ok(arr).header("hash", calcHashImg(arr)).build();
   }
 
   private int calcHashImg(byte[] img) {

--- a/src/test/java/com/taskforce/moneyapp/dao/TestAccountDAO.java
+++ b/src/test/java/com/taskforce/moneyapp/dao/TestAccountDAO.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.List;
-import java.util.Set;
 
 import static junit.framework.TestCase.assertTrue;
 
@@ -33,7 +32,7 @@ public class TestAccountDAO {
 
 	@Test
 	public void testGetAllAccounts() throws CustomException {
-		Set<Account> allAccounts = h2DaoFactory.getAccountDAO().getAllAccounts();
+		List<Account> allAccounts = h2DaoFactory.getAccountDAO().getAllAccounts();
 		assertTrue(allAccounts.size() > 1);
 	}
 

--- a/src/test/resources/demo.sql
+++ b/src/test/resources/demo.sql
@@ -2,17 +2,17 @@
 
 DROP TABLE IF EXISTS User;
 
-CREATE TABLE User (UserId LONG PRIMARY KEY NOT NULL,
+CREATE TABLE User (UserId LONG PRIMARY KEY AUTO_INCREMENT NOT NULL,
  UserName VARCHAR(30) NOT NULL,
  EmailAddress VARCHAR(30) NOT NULL);
 
 CREATE UNIQUE INDEX idx_ue on User(UserName,EmailAddress);
 
-INSERT INTO User (UserId, UserName, EmailAddress) VALUES (1, 'test2','test2@gmail.com');
-INSERT INTO User (UserId, UserName, EmailAddress) VALUES (2, 'test1','test1@gmail.com');
-INSERT INTO User (UserId, UserName, EmailAddress) VALUES (3, 'yangluo','yangluo@gmail.com');
-INSERT INTO User (UserId, UserName, EmailAddress) VALUES (4, 'qinfran','qinfran@gmail.com');
-INSERT INTO User (UserId, UserName, EmailAddress) VALUES (5, 'liusisi','liusisi@gmail.com');
+INSERT INTO User (UserName, EmailAddress) VALUES ('test2','test2@gmail.com');
+INSERT INTO User (UserName, EmailAddress) VALUES ('test1','test1@gmail.com');
+INSERT INTO User (UserName, EmailAddress) VALUES ('yangluo','yangluo@gmail.com');
+INSERT INTO User (UserName, EmailAddress) VALUES ('qinfran','qinfran@gmail.com');
+INSERT INTO User (UserName, EmailAddress) VALUES ('liusisi','liusisi@gmail.com');
 
 DROP TABLE IF EXISTS Account;
 


### PR DESCRIPTION
В исходной версии CPU usage, если смотреть через top начинается с 80 процентов и далее растет более 90.
В мониторе jvisualvm видим что CPU usage растет от 4.5% приближаясь к 10%.
Used heap растет приблизительно от 25 МБ до 100 в течение некоторого времени, далее full gc и цикл повторяется.

[https://drive.google.com/open?id=1ot7r-zDCosD-IIFCQa2pixUo2BTZs6x0](url)

Used metaspace стабильно около 26 МБ.

Включаем сэмплер. Видим на thread cpu time, что самое большое значение для треда qtp317983781-59. На CPU samples видим, что 95% self time занимает com.moneytransfer.dao.impl.AccountDAOImpl.getAllAccounts(). Делаем снэпшот. Переходим на Hot Spots. Видим, что 93,9 self time занимает java.util.HashSet.add().
Начинаем оптимизацию в него. Видим, что в AccountDAOImpl.getAllAccounts() на первый взгляд ничего криминального, но здесь как раз есть HashSet, в которую на каждой итерации добавляется Account. Профайлер как раз нам показывал, что потенциальная проблема с java.util.HashSet.add(). Смотрим, почему добавление может вызывать проблему. Видим что в классе Account hashCode() возвращает константу. Вот и причина, постоянные коллизии при добавлении.

Тест проводился на 10000 итераций. Среднее значение времени выполнении сценария достигло 0.473. Динамика роста видна на графике (далее на всех графиках пропускаются первые 100 итераций для большей наглядности, т. к. в начале работы приложения всегда наблюдается всплеск показателей):

[https://drive.google.com/file/d/1OobAK7_VkBv_h7f2a8BdY2fa2ZInZnOy/view?usp=sharing](url)

Видим, что рост нелинейный. Этот результат понятен, т. к. уже при получении getAllAccounts() мы получаем нелинейный рост (каждая из n вставок занимает линейное время относительно текущего количества элементов в таблице).

Посмотрим, что изменилось после этого исправления. 
Среднее значение CPU usage по top 63%, по данным монитора 5%:

[https://drive.google.com/open?id=1dqbHDGFw7R7KXfCMQ-GxUI4a1DeR-68z](url)

Динамика по памяти продолжает демонстрировать картину утечек (этим займемся чуть позднее):

[https://drive.google.com/file/d/1Lia6G3HsH10pyLNNGnBL0avttQVNppt4/view?usp=sharing](url)

Среднее время выполнения сценария уменьшилось до 0.064 с. Динамика изменения среднего времени по сравнению с вариантом до оптимизации приведена на графике:

[https://drive.google.com/file/d/10rCC_qLvlea-8ySH7Y7__hz4sgSusMg7/view?usp=sharing](url)

Далее проведем исследование с помощью профайлера.
По итогам в снэпшоте видим:
1. В самом тяжелом треде видим, что больше всего времени занял метод com.moneytransfer.service.AccountService.getAccount (17,4 %):
[https://drive.google.com/file/d/1pQDYY9OkzIAXh00YiRVaDUpiUTWFBINC/view?usp=sharing](url)
он занял даже больше, чем getAllAccounts. Это странно. Пройдя ниже по стеку вызовов, видим в чем причина:
[https://drive.google.com/file/d/1aAan4JGdIvBR3SQw1u2aYFstQSqg9AOs/view?usp=sharing](url)
т. е. getAccount вызывает getAccountByUser, а тот в свою очередь вызывает getAllAccounts. Получается, что метод, возвращающий счет по пользователю, получает список всех пользователей.
2. Рассматривая в текущем треде методы далее в порядке убывания времени видим следующую проблему:
[https://drive.google.com/file/d/1uukV1GWWiKuP1DU4JprcJNmAomhz1QTS/view?usp=sharing](url)
т. е. при создании пользователя вызывается метод вставки пользователя, который получает список всех пользователей. Это не логично и нужно исправить.
Также заметим (по коду), что для получения всех счетов используется HashSet, однако по сути в дальнейшем возможности HashSet нигде не используются, поэтому можно, как и для пользователей, использовать список, что будет более эффективно для текущего варианта использования коллекции счетов.

После оптимизации среднее значение CPU usage по top 54%, по данным монитора 4,5%. 
[https://drive.google.com/file/d/1lRyaLyygptEW7U07zZwK_0eLdVtQvV72/view?usp=sharing](url)
Среднее значение выполнения сценария уменьшилось до 0.058 с при сохранении прежней динамики роста.
Проведем исследование с помощью профайлера.
По итогам в снэпшоте видим, что com.moneytransfer.service.UserService.getAllUsers() занимает больше времени, чем com.moneytransfer.service.AccountService.getAllAccounts():
[https://drive.google.com/file/d/10OuEeMzt--o3EvFM9JqYUVXizjE_NqyG/view?usp=sharing](url)
Это странно. По смыслу эти 2 метода должны занимать близкое время, но getAllAccounts() чуть больше, т. к.:
1. В нашем сценарии для каждого пользователя есть счет
2. Представление (toString) счета немного длинее, чем пользователя

Из стека непонятно, почему так. Поэтому смотрим в код и видим лишние действия, которые нужно убрать.

Теперь посмотрим насчет утечек памяти. Для этого запустим профилировку памяти, установив предварительно record allocations stack traces. Делаем 2 снэпшота с небольшим промежутком времени. Затем сравним их. В результате видим следующий результат:
[https://drive.google.com/file/d/1zLpwDLCxQMUnpFImOSzBDfGIHJ-zHQ2x/view?usp=sharing](url)
Массив чаров, который находится в топе дает мало информации. Посмотрим на второй результат: java.sql.DriverInfo.
Для этого идем опять в профилировщик, находим там java.sql.DriverInfo и делаем stack trace.
Видим следующее:
[https://drive.google.com/file/d/1odT5iCt5HsU7oVWo5-6-vfALqbsg1bO9/view?usp=sharing](url)
Теперь понятно, куда смотреть в код. В getUserDAO() и getAccountDAO() действительно каждый раз производится загрузка драйвера, хотя это уже сделано в блоке статической инициализации.

После этой и прочих оптимизаций получаем следующий результат:
CPU usage по данным top 47%, по данным монитора около 4%.
[https://drive.google.com/file/d/11ErXT-HRT7AogpwQ0yNJbFQCIs8JsOzL/view?usp=sharing](url)
Использование памяти стало лучше:
[https://drive.google.com/file/d/1JclaDMHnflJCFoRSs7gybtE3qTM8MdV8/view?usp=sharing](url)
Среднее время выполнения сценария: 0.043 с.

**GC.** 
Сборщики мусора тестировались с настройками по-умолчанию (кроме G1).

1. Serial GC 
Среднее время выполнения сценария 0.044 с.
CPU usage 3,7%.
used heap около 75 Мб:
[https://drive.google.com/file/d/1r9A6UgqKEvek3hQZ5U2HiLRraY6IeFzp/view?usp=sharing](url)
1 полная сборка, 3218 сборок в младшем поколении, длительность сборок около 9 сек. 

2. Parallel GC
Среднее время выполнения сценария 0.043 с.
CPU usage 4%.
used heap в пиках до 500 Мб:
[https://drive.google.com/file/d/1vJpRrrNX3_1-YpcUIwAtf_NxZtliltUf/view?usp=sharing](url)
2 полные сборки, 1335 сборок в младшем поколении, длительность сборок около 3,25 сек. 

3. CMS GC
Среднее время выполнения сценария 0.045 с.
CPU usage 5%.
used heap около 75 Мб:
[https://drive.google.com/file/d/1nbKY6IewU_hzoYwpzgmArhUoLwNtGf3r/view?usp=sharing](url)
2 полные сборки, 3224 сборок в младшем поколении, длительность сборок около 7,2 сек. 

4. G1 GC
Среднее время выполнения сценария 0.046 с.
CPU usage 6%.
used heap выросло почти до 900 Мб:
[https://drive.google.com/file/d/1EXkU8gK5RnexwUrHoy6__Bf8zjsdnR8M/view?usp=sharing](url)
Длительность сборок около 9,7 сек. 

Это интересно, поскольку здесь наблюдается явная деградация производительности. В visual GC заметно, что last cause сборки постоянно меняется с evacuation pause на humongous allocation. Это может быть из-за того, что в нашем сценарии создается много больших объектов (получение списка всех счетов и всех пользователей), а G1 к этому чувствителен.

Попробуем поменять настройки по-умолчанию, чтобы решить эту проблему.

1. -XX:G1HeapRegionSize=4m
CPU usage около 6%
[https://drive.google.com/file/d/1YaUX3GUHZOpasIFSGfqWypdjb_Re_8C1/view?usp=sharing](url)
used heap резкий рост в конце более 350 Мб.
[https://drive.google.com/file/d/1t3dVBhu6G1a30SWIPD1nFAwrom9wGNUl/view?usp=sharing](url)
Длительность сборок 6 с.
Среднее время выполнения сценария 0.045 с.

2. -XX:G1HeapRegionSize=8m
CPU usage около 4%
[https://drive.google.com/file/d/1ntbZSB9uQCzV2yZbt-tEEPGnxYLibkfN/view?usp=sharing](url)
used heap менее 175 Мб. Роста как с дефолтными настройками не наблюдается.
[https://drive.google.com/file/d/1iBVj7ES_PCiF5xx9t2bG99IDqaw4ygpb/view?usp=sharing](url)
Длительность сборок 4,2 с.
Среднее время выполнения сценария 0.045 с.

3. -XX:G1HeapRegionSize=16m
CPU usage около 4,7%
[https://drive.google.com/file/d/1kihp3ANicZv2Cf6_k1XRsBmtjXw6kLTr/view?usp=sharing](url)
used heap до 150 Мб. Роста как с дефолтными настройками не наблюдается.
[https://drive.google.com/file/d/1gw9LzCbBO6eCBp_bDdPd_l-q0rAuuAO6/view?usp=sharing](url)
Длительность сборок 4,24 с.
Среднее время выполнения сценария 0.045 с.

4. -XX:G1HeapRegionSize=32m
CPU usage около 4,3%
[https://drive.google.com/file/d/141HYF6vm7sdGMJOpGAJKW2vT-484vhcE/view?usp=sharing](url)
used heap до 100 Мб. Роста как с дефолтными настройками не наблюдается.
[https://drive.google.com/file/d/14K5lX-Y8kV_FmBlS5EkLWIPFzhmwRCY_/view?usp=sharing](url)
Длительность сборок 5,4 с.
Среднее время выполнения сценария 0.045 с.

5. -XX:G1HeapRegionSize=64m
CPU usage около 4,5%
[https://drive.google.com/file/d/1TfwZS21-OqrlhRlBaHNnNbGfsK-DqN9V/view?usp=sharing](url)
used heap вырастает чуть более 100 Мб. 
[https://drive.google.com/file/d/1XYvYTFaqRBnvjL9Lx6FvbIOSbhBtCoYG/view?usp=sharing](url)
Длительность сборок 5,46 с.
Среднее время выполнения сценария 0.046 с.

Как итог видим, что самым скромным в потреблении ресурсов оказывается Serial GC. Parallel GC агрессивно использует память, но обеспечивает самые лучшие результаты в минимизации среднего времени выполнения нашего тестового сценария. CMS GC довольно скромен к ресурсам, меньшее общее время сборок по сравнению с  Serial GC. G1 GC чувствителен к большим объектам в памяти. В нашем сценарии с настройками по-умолчанию демонстрирует явную деградацию производительности, использует много ресурсов и проседает по среднему времени выполнения сценария, общее время сборок оказывается самым большим. После настойки параметра G1HeapRegionSize ситуация исправляется. В ходе экспериментов лучшее из тестированных значений оказалось -XX:G1HeapRegionSize=8m. По поводу того, какой GC выбрать для данного приложения. Если требуется минимизировать время выполнения нашего сценария, то Parallel GC, если важно не только среднее время, но и ресурсы, и время отклика, то CMS GC, потому что из-за особенностей сценарий (активное создание больших объектов) G1 ведет себя не очень предсказуемо. Нет уверенности, что то значение параметра  G1HeapRegionSize, которое было подобрано, будет показывать хороший результат например под более высокой нагрузкой, при большем объеме данных.