### PR TITLE
Home task JVM, Nagaev Iscander

### DIFF
--- a/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
+++ b/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
@@ -38,12 +38,12 @@ public class H2DAOFactory extends DAOFactory {
 	}
 
 	public UserDAO getUserDAO() {
-		DbUtils.loadDriver(h2_driver);
+		//DbUtils.loadDriver(h2_driver); Commented by Isc
 		return new UserDAOImpl();
 	}
 
 	public AccountDAO getAccountDAO() {
-		DbUtils.loadDriver(h2_driver);
+		//DbUtils.loadDriver(h2_driver); Commented by Isc
 		return new AccountDAOImpl();
 	}
 
@@ -54,6 +54,9 @@ public class H2DAOFactory extends DAOFactory {
 		try {
 			conn = H2DAOFactory.getConnection();
 			RunScript.execute(conn, new FileReader("src/test/resources/demo.sql"));
+			//Added by Isc
+			accountDAO.getTestAccountsFromDB();
+			//------------------
 		} catch (SQLException e) {
 			log.error("populateTestData(): Error populating user data: ", e);
 			throw new RuntimeException(e);

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -18,6 +18,11 @@ import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Set;
 
+//Added by Isc
+import java.util.HashMap;
+import java.util.Map;
+//---------------------
+
 public class AccountDAOImpl implements AccountDAO {
 
   private static Logger log = Logger.getLogger(AccountDAOImpl.class);
@@ -29,14 +34,23 @@ public class AccountDAOImpl implements AccountDAO {
   private final static String SQL_GET_ALL_ACC = "SELECT * FROM Account";
   private final static String SQL_DELETE_ACC_BY_ID = "DELETE FROM Account WHERE AccountId = ?";
 
+//Added by Isc
+  private static Map<Long, Account> AccountId_Map = new HashMap<>();
+  private static Map<String, Account> AccountUserName_Map = new HashMap<>();  
+//  
+  
   /**
    * Get all accounts.
    */
   public Set<Account> getAllAccounts() throws CustomException {
+    Set<Account> allAccounts = new HashSet<Account>(AccountId_Map.values());
+    return allAccounts;
+    
+/*  Commented by Isc	  
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
-    Set<Account> allAccounts = new HashSet<>();
+  
     try {
       conn = H2DAOFactory.getConnection();
       stmt = conn.prepareStatement(SQL_GET_ALL_ACC);
@@ -55,12 +69,51 @@ public class AccountDAOImpl implements AccountDAO {
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/    
   }
 
+  
+  /* Added by Isc
+   * get test accounts from DB
+   */
+  public long getTestAccountsFromDB() throws CustomException {
+	  	long counter=0;
+	    Connection conn = null;
+	    PreparedStatement stmt = null;
+	    ResultSet rs = null;
+	    try {
+	      conn = H2DAOFactory.getConnection();
+	      stmt = conn.prepareStatement(SQL_GET_ALL_ACC);
+	      rs = stmt.executeQuery();
+	      while (rs.next()) {
+	        Account acc = new Account(rs.getLong("AccountId"), rs.getString("UserName"),
+	            rs.getBigDecimal("Balance"), rs.getString("CurrencyCode"));
+	        if (log.isDebugEnabled()) {
+	          log.debug("getAllAccounts(): Get  Account " + acc);
+	        }
+	        //Add test accounts
+	        log.info("getTestAccountsFromDB(): Adding test Account " + acc);
+	        createAccount(acc);
+	        counter=counter+1;
+	      }
+	      return counter;
+	    } catch (SQLException e) {
+	      throw new CustomException("getAccountById(): Error reading account data", e);
+	    } finally {
+	      DbUtils.closeQuietly(conn, stmt, rs);
+	    }
+	  }
+  
   /**
    * Get account by id
    */
   public Account getAccountById(long accountId) throws CustomException {
+	Account acc = AccountId_Map.get(accountId);
+    if (log.isDebugEnabled()) {
+      log.debug("Retrieve Account By Id: " + acc);
+    }
+    return acc;
+/*    
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
@@ -83,9 +136,16 @@ public class AccountDAOImpl implements AccountDAO {
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/    
   }
 
   public Account getAccountByUser(String user, String currency) throws CustomException {
+	Account acc = AccountUserName_Map.get(user+currency);
+    if (log.isDebugEnabled()) {
+      log.debug("Retrieve Account By userId: " + acc);
+    }
+    return acc;
+/* Commented by Isc	finally  
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
@@ -103,22 +163,40 @@ public class AccountDAOImpl implements AccountDAO {
           log.debug("Retrieve Account By userId: " + acc);
         }
       }
+      return acc;
+/* Commented by Isc      
       return getAllAccounts()
           .stream()
           .filter(account -> account.getUserName().equals(user) && account.getCurrencyCode().equals(currency))
           .findFirst()
           .orElse(null);
+*/
+/* Commented by Isc	finally
     } catch (SQLException e) {
       throw new CustomException("getAccountById(): Error reading account data", e);
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/
   }
 
   /**
    * Create account
    */
   public long createAccount(Account account) throws CustomException {
+	String UserName = account.getUserName();
+	String CurrencyCode = account.getCurrencyCode();
+	if (getAccountByUser(UserName, CurrencyCode) != null) {
+		log.error("Error Inserting Account  " + account);
+		throw new CustomException("Account already exists" + account, null);
+	}
+    long num = AccountId_Map.size()+1;
+    Account acc = new Account(num, UserName, account.getBalance(), CurrencyCode);
+	AccountId_Map.put(num, acc);
+	AccountUserName_Map.put(UserName+CurrencyCode, acc);
+	
+	return num;  
+/*	Commented by Isc  
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet generatedKeys = null;
@@ -146,12 +224,27 @@ public class AccountDAOImpl implements AccountDAO {
     } finally {
       DbUtils.closeQuietly(conn, stmt, generatedKeys);
     }
+*/    
   }
 
   /**
    * Delete account by id
    */
   public int deleteAccountById(long accountId) throws CustomException {
+	Account acc = getAccountById(accountId);
+	if (acc == null) {
+        if (log.isDebugEnabled()) {
+            log.debug("No account found with userId: " + accountId);
+        }
+		
+		return 0;	//no
+	}
+	
+	AccountId_Map.remove(accountId);
+	AccountUserName_Map.remove(acc.getUserName()+acc.getCurrencyCode());
+
+	return 1;
+/* Commented by Isc 	  
     Connection conn = null;
     PreparedStatement stmt = null;
     try {
@@ -165,12 +258,31 @@ public class AccountDAOImpl implements AccountDAO {
       DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(stmt);
     }
+*/    
   }
 
   /**
    * Update account balance
    */
   public int updateAccountBalance(long accountId, BigDecimal deltaAmount) throws CustomException {
+	  Account targetAccount = getAccountById(accountId);
+	  if (targetAccount == null) {
+	      throw new CustomException("updateAccountBalance(): fail to lock account : " + accountId);
+	  }
+	  if (log.isDebugEnabled()) {
+	      log.debug("updateAccountBalance from Account: " + targetAccount);
+	  }
+	  
+	  BigDecimal balance = targetAccount.getBalance().add(deltaAmount);
+	  if (balance.compareTo(MoneyUtil.zeroAmount) < 0) {
+	      throw new CustomException("Not sufficient Fund for account: " + accountId);
+	  }
+	    targetAccount.setBalance(balance);
+	    if (log.isDebugEnabled()) {
+	      log.debug("New Balance after Update: " + targetAccount);
+	    }
+	    return 1;
+/*	  
     Connection conn = null;
     PreparedStatement lockStmt = null;
     PreparedStatement updateStmt = null;
@@ -226,13 +338,75 @@ public class AccountDAOImpl implements AccountDAO {
       DbUtils.closeQuietly(updateStmt);
     }
     return updateCount;
+*/    
   }
 
   /**
    * Transfer balance between two accounts.
    */
   public int transferAccountBalance(UserTransaction userTransaction) throws CustomException {
-    int result = -1;
+	int result = -1;
+	Account fromAccount = getAccountById(userTransaction.getFromAccountId());
+	if (fromAccount == null) {
+	    throw new CustomException("Fail to lock fromAccount for write");
+	}
+	if (log.isDebugEnabled()) {
+	    log.debug("transferAccountBalance from Account: " + fromAccount);
+	}
+	
+	Account toAccount = getAccountById(userTransaction.getToAccountId());
+	if (toAccount == null) {
+	    throw new CustomException("Fail to lock toAccount for write");
+	}
+	if (log.isDebugEnabled()) {
+	    log.debug("transferAccountBalance to Account: " + toAccount);
+	}
+	
+    // check transaction currency
+    if (!fromAccount.getCurrencyCode().equals(userTransaction.getCurrencyCode())) {
+      throw new CustomException(
+          "Fail to transfer Fund, transaction ccy are different from source/destination");
+    }
+
+    // check ccy is the same for both accounts
+    if (!fromAccount.getCurrencyCode().equals(toAccount.getCurrencyCode())) {
+      throw new CustomException(
+          "Fail to transfer Fund, the source and destination account are in different currency");
+    }
+
+    // check enough fund in source account
+    BigDecimal fromAccountLeftOver = fromAccount.getBalance().subtract(userTransaction.getAmount());
+    if (fromAccountLeftOver.compareTo(MoneyUtil.zeroAmount) < 0) {
+      throw new CustomException("Not enough Fund from source Account ");
+    }
+
+    // proceed with update
+	BigDecimal FromAccountBalance_saved = fromAccount.getBalance();
+	BigDecimal ToAccountBalance_saved = toAccount.getBalance();
+	try {
+		BigDecimal FromAccountBalance_new = fromAccountLeftOver;
+		BigDecimal ToAccountBalance_new = toAccount.getBalance().add(userTransaction.getAmount());
+		fromAccount.setBalance(FromAccountBalance_new);
+	    toAccount.setBalance(ToAccountBalance_new);
+	    if (log.isDebugEnabled()) {
+	        log.debug("Number of rows updated for the transfer : " + result);
+	    }
+	    
+	    result = 2;	    
+	} catch (Exception e) {
+	    log.error("transferAccountBalance(): User Transaction Failed, rollback initiated for: " + userTransaction, e);
+	    try {
+	        fromAccount.setBalance(FromAccountBalance_saved);
+	        toAccount.setBalance(ToAccountBalance_saved);
+	    } catch (Exception re) {
+	        throw new CustomException("Fail to rollback transaction", re);
+	    }
+	}
+
+	return result;
+    
+/* Commented by Isc 	  
+	  int result = -1;
     Connection conn = null;
     PreparedStatement lockStmt = null;
     PreparedStatement updateStmt = null;
@@ -320,4 +494,7 @@ public class AccountDAOImpl implements AccountDAO {
     }
     return result;
   }
+*/  
+}
+  
 }

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -3,6 +3,7 @@ package com.moneytransfer.dao.impl;
 import com.moneytransfer.dao.H2DAOFactory;
 import com.moneytransfer.dao.UserDAO;
 import com.moneytransfer.exception.CustomException;
+import com.moneytransfer.model.Account;
 import com.moneytransfer.model.User;
 
 import org.apache.commons.dbutils.DbUtils;
@@ -11,6 +12,12 @@ import org.apache.log4j.Logger;
 import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
+//Added by Isc
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+//---------------------
+import java.util.Set;
 
 public class UserDAOImpl implements UserDAO {
 
@@ -22,12 +29,21 @@ public class UserDAOImpl implements UserDAO {
   private final static String SQL_UPDATE_USER = "UPDATE User SET UserName = ?, EmailAddress = ? WHERE UserId = ? ";
   private final static String SQL_DELETE_USER_BY_ID = "DELETE FROM User WHERE UserId = ? ";
 
-  private List<User> fetched = new ArrayList<>();
+  //Commented by Isc
+  //private List<User> fetched = new ArrayList<>(); 
+  //--------------------------
+  // Added by Isc
+  private static Map<Long, User> userId_Map = new HashMap<>();
+  private static Map<String, User> userName_Map = new HashMap<>();
 
   /**
    * Find all users
    */
   public List<User> getAllUsers() throws CustomException {
+	List<User> allUsers = new ArrayList<User>(userId_Map.values());
+	return allUsers;
+  
+/* Commented by Isc	  
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
@@ -42,19 +58,26 @@ public class UserDAOImpl implements UserDAO {
         if (log.isDebugEnabled())
           log.debug("getAllUsers() Retrieve User: " + u);
       }
-      fetched.addAll(users);
+      //fetched.addAll(users); Commented by Isc
       return users;
     } catch (SQLException e) {
       throw new CustomException("Error reading user data", e);
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/    
   }
 
   /**
    * Find user by userId
    */
   public User getUserById(long userId) throws CustomException {
+	User u = userId_Map.get(userId);
+	if (log.isDebugEnabled()) {
+		log.debug("getUserById(): Retrieve User: " + u);
+	}
+	return u;
+/* Commented by Isc	  
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
@@ -75,12 +98,20 @@ public class UserDAOImpl implements UserDAO {
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/    
   }
 
   /**
    * Find user by userName
    */
   public User getUserByName(String userName) throws CustomException {
+	User u = userName_Map.get(userName);
+	if (log.isDebugEnabled()) {
+		log.debug("Retrieve User: " + u);
+	}
+	return u;  
+	
+/* Commented by Isc	
     Connection conn = null;
     PreparedStatement stmt = null;
     ResultSet rs = null;
@@ -101,13 +132,27 @@ public class UserDAOImpl implements UserDAO {
     } finally {
       DbUtils.closeQuietly(conn, stmt, rs);
     }
+*/    
   }
 
   /**
    * Save User
    */
   public long insertUser(User user) throws CustomException {
-    Connection conn = null;
+	String UserName = user.getUserName();
+	if (getUserByName(UserName) != null) {
+	    log.error("insertUser(): Creating user failed," + user + ", already exists.");
+	    throw new CustomException("Error creating user data", null);
+	}
+	
+	long num = userId_Map.size()+1;
+	User u = new User(num, UserName, user.getEmailAddress());
+	userId_Map.put(num, u);
+	userName_Map.put(UserName, u);
+	return num;
+	
+/*	Commented by Isc  
+	  Connection conn = null;
     PreparedStatement stmt = null;
     try {
       conn = H2DAOFactory.getConnection();
@@ -128,13 +173,31 @@ public class UserDAOImpl implements UserDAO {
     } finally {
       DbUtils.closeQuietly(conn);
     }
-
+*/
   }
 
   /**
    * Update User
    */
   public int updateUser(Long userId, User user) throws CustomException {
+	  User user_in_db = getUserById(userId);
+	  if (user_in_db == null) {
+		  log.error("No user found" + userId);
+	      throw new CustomException("Error update user data");
+	  }
+	  user_in_db.setUserName(user.getUserName());
+	  user_in_db.setEmailAddress(user.getEmailAddress());
+	  try {
+		  userName_Map.remove(user_in_db.getUserName());
+	      User u = new User(userId, user.getUserName(), user.getEmailAddress());
+	      userName_Map.put(user.getUserName(), u);
+	  } catch (Exception e) {
+	      log.error("Error Updating User :" + user);
+	      throw new CustomException("Error update user data", e);
+	  }
+	  return 1;
+	    
+/*	Commented by Isc  
     Connection conn = null;
     PreparedStatement stmt = null;
 
@@ -152,12 +215,24 @@ public class UserDAOImpl implements UserDAO {
       DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(stmt);
     }
+*/    
   }
 
   /**
    * Delete User
    */
   public int deleteUser(long userId) throws CustomException {
+	User user = getUserById(userId);
+	if (user == null) {
+	   log.error("Error Deleting User :" + userId);
+	   throw new CustomException("Error Deleting User ID:" + userId);
+	}
+	
+	userId_Map.remove(userId);
+	userName_Map.remove(user.getUserName());
+	return 1;
+	 
+/*	Commented by Isc  
     Connection conn = null;
     PreparedStatement stmt = null;
 
@@ -173,5 +248,7 @@ public class UserDAOImpl implements UserDAO {
       DbUtils.closeQuietly(conn);
       DbUtils.closeQuietly(stmt);
     }
+    */
   }
+ 
 }

--- a/src/main/java/com/moneytransfer/model/Account.java
+++ b/src/main/java/com/moneytransfer/model/Account.java
@@ -45,6 +45,12 @@ public class Account {
     return balance;
   }
 
+  public BigDecimal setBalance(BigDecimal new_balance) {
+	    balance=new_balance;
+	    return balance;
+	  }
+  
+  
   public String getCurrencyCode() {
     return currencyCode;
   }
@@ -64,7 +70,11 @@ public class Account {
 
   @Override
   public int hashCode() {
-    return 1;
+	  int result = (int) (accountId ^ (accountId >>> 32));
+	    result = 31 * result + userName.hashCode();
+	    result = 31 * result + currencyCode.hashCode();
+	    return result;	  
+//    return 1; commented by Isc
   }
 
   @Override

--- a/src/main/java/com/moneytransfer/model/User.java
+++ b/src/main/java/com/moneytransfer/model/User.java
@@ -34,10 +34,24 @@ public class User {
     return userName;
   }
 
+//Added by Isc 
+  public String setUserName(String new_UserName) {
+	userName=new_UserName;
+	return userName;
+  }
+//-----------------------
+
   public String getEmailAddress() {
-    return emailAddress;
+	return emailAddress;
   }
 
+ //Added by Isc 
+  public String setEmailAddress(String new_EmailAddress) {
+	emailAddress=new_EmailAddress;
+	return emailAddress;
+  }
+ //-----------------
+  
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;


### PR DESCRIPTION
Первоначально:

При запуске run_tests_py
CPU Usage сначала около 30%, потом поднимается до 40-45%.
Heap Size  сначала около 17 Мб, потом растет до 28 Мб, потом продолжается медленное, но неуклонное увеличение потребляемой памяти
GC происходит 3-4 раза в секунду
Сценарий выполняется от 0.4 секунды и постепенно увеличивается по 0.001 секунды за 6 вызовов

Загрузка CPU
Использование сэмплера:
Больше всего по времени выполняется функция
sun.nio.ch.ServerSocketChannelImpl.accept ()
Можем предположить, что это функция ожидает установление соединения с сервером и вряд ли может быть оптимизирована. 
На втором месте 
java.util.HashSet.add ()
которая вызывается из com.moneytransfer.dao.impl.AccountDAOImpl.getAccountByUser ()

Использование  профайлера:
Больше всего по времени выполняется функция 
com.moneytransfer.dao.impl.AccountDAOImpl.getAllAccounts ()
которая вызывается из com.moneytransfer.dao.impl.AccountDAOImpl.getAccountByUser ()
На втором месте 
com.moneytransfer.model.Account.equals (Object)
которая вызывается из com.moneytransfer.dao.impl.AccountDAOImpl.getAllAccounts ()

Память
Использование сэмплера:
Мало, что понятно: на первых местах массивы chat, byte, int
На следующие позиции выбирается
java.util.HashMap$TreeNode
и 
java.sql.DriverInfo

Использование профайлера
Профилирование класса com.moneytransfer. ** показывает, что больше всего памяти используется функции 
com.moneytransfer.dao.impl.AccountDAOImpl.getAllAccounts ()
На втором месте функция
com.moneytransfer.dao.impl.UserDAOImpl.getAllUsers ()
Итого: нужно обратить внимание на модули 
com.moneytransfer.dao.impl.AccountDAOImpl
и 
com.moneytransfer.dao.impl.UserDAOImpl

После оптимизации:

После оптимизации кода (вычисление хэша, удаление  getAllAccounts() из getAccountByUser () и т.д.) сценарий стал выполняться быстрее, но память все равно утекает.
В сэмплере на второе место выходит функция
java.sql.DriverManager.registerDriver (), которая вызывается через серию вызовов в функции com.moneytransfer.dao.H2DAOFactory.getAccountDAO ()
Соответственно убираем лишние вызовы LoadDriver().
В итоге CPU Usage колеблется около 30-35%, потребляемая память медленно доросла до40 Мб и практически остановилась. 

Использование сборщиков мусора

-XX:+UseSerialGC
CPU Usage около 30%, GC activity вырос с 6 до 12%, потребление памяти дошло до 35 МБ и остановилось. Рост почти линейный.

-XX:+UseParallelGC
CPU Usage около 20%, GC activity около 0.4%, потребление памяти сначала было 100 МБ, потом пилообразно упало до 50МБ, потом пилообразно выросло до 110 МБ и сильно колеблется около этих значений.

-XX:+UseConcMarkSweepGC
CPU Usage около 25%, GC activity около 0.7%, потребление памяти сначала с 16МБ  резким скачком выросла до 70 МБ, потом вторым резким скачком выросла до 110 МБ и остановилось.

-XX:+UseG1GC
CPU Usage сначала вырос до 40%, потом опустился к 25%, GC activity колеблется от  0.2% до 1.4%, потребление памяти сначала с 16МБ быстро выросло до 65Мб, потом после значительного по времени плато быстро линейно выросло до 265 МБ и остановилось.

Лично мне кажется наиболее правильным использовать -XX:+UseSerialGC для данной программы.

Переписывание кода

Переписал AccountDAOImpl и UserDAOImpl с использованием HashMap. И это не работало, так как тестовые пользователи добавлялись в H2DAOFactory. Пришлось переписывать и его.
В итоге, не все тесты проходят, как обрабатывать ситуацию с созданием уже существующего аккаунта, я не знаю и просто выкидываю эксепшн. Собрал проект с  ключом -DskipTests=true. Питон-сценарий отрабатывает без ошибок. Производительность поднять удалось.
