### PR TITLE
Фурсов А.С. (без последнего задания)

### DIFF
--- a/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
+++ b/src/main/java/com/moneytransfer/dao/H2DAOFactory.java
@@ -39,12 +39,12 @@ public class H2DAOFactory extends DAOFactory {
 
 	public UserDAO getUserDAO() {
 		DbUtils.loadDriver(h2_driver);
-		return new UserDAOImpl();
+		return userDAO;
 	}
 
 	public AccountDAO getAccountDAO() {
 		DbUtils.loadDriver(h2_driver);
-		return new AccountDAOImpl();
+		return accountDAO;
 	}
 
 	@Override

--- a/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/AccountDAOImpl.java
@@ -103,11 +103,7 @@ public class AccountDAOImpl implements AccountDAO {
           log.debug("Retrieve Account By userId: " + acc);
         }
       }
-      return getAllAccounts()
-          .stream()
-          .filter(account -> account.getUserName().equals(user) && account.getCurrencyCode().equals(currency))
-          .findFirst()
-          .orElse(null);
+      return acc;
     } catch (SQLException e) {
       throw new CustomException("getAccountById(): Error reading account data", e);
     } finally {

--- a/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
+++ b/src/main/java/com/moneytransfer/dao/impl/UserDAOImpl.java
@@ -22,8 +22,6 @@ public class UserDAOImpl implements UserDAO {
   private final static String SQL_UPDATE_USER = "UPDATE User SET UserName = ?, EmailAddress = ? WHERE UserId = ? ";
   private final static String SQL_DELETE_USER_BY_ID = "DELETE FROM User WHERE UserId = ? ";
 
-  private List<User> fetched = new ArrayList<>();
-
   /**
    * Find all users
    */
@@ -42,7 +40,6 @@ public class UserDAOImpl implements UserDAO {
         if (log.isDebugEnabled())
           log.debug("getAllUsers() Retrieve User: " + u);
       }
-      fetched.addAll(users);
       return users;
     } catch (SQLException e) {
       throw new CustomException("Error reading user data", e);

--- a/src/main/java/com/moneytransfer/model/Account.java
+++ b/src/main/java/com/moneytransfer/model/Account.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.math.BigDecimal;
 
+import java.util.Objects;
+
 public class Account {
 
   private long accountId;
@@ -64,7 +66,7 @@ public class Account {
 
   @Override
   public int hashCode() {
-    return 1;
+    return Objects.hash(accountId, userName, balance, currencyCode);
   }
 
   @Override


### PR DESCRIPTION
<h2>Запуск №1</h2>
		<p>CPU: 20-22%</p>
		<p>Память скачет и растет с 25 МБ. Очевидна утечка.</p>
		<table>
			<tr>
				<td>Количество итераций</td>
				<td>1000</td>
				<td>2000</td>
				<td>3000</td>
			</tr>
			<tr>
				<td>Среднее время</td>
				<td>0.133</td>
				<td>0.182</td>
				<td>0.255</td>
			</tr>
		</table>
		<p>VisualVm сообщает нам, что метод getAllAccounts выполняется достаточно большое количество времени. Рассматриваем call tree. Мне показалось странным, что данный метод вызывается методом getAccountByUser. При изучении последнего установлено, что метод сначала самостоятельно обращается к базе, а затем вызывает метод getAllAccounts, получая с помощью него информацию второй раз. Устраним найденные ошибки.</p>
		<h2>Запуск №2</h2>
		<p>CPU: 15-16%</p>
		<p>Память скачет и растет с 25 МБ. Очевидна утечка.</p>
		<table>
			<tr>
				<td>Количество итераций</td>
				<td>1000</td>
				<td>2000</td>
				<td>3000</td>
			</tr>
			<tr>
				<td>Среднее время</td>
				<td>0.117</td>
				<td>0.132</td>
				<td>0.166</td>
			</tr>
		</table>
		<p>Анализируя статистику, замечаем, что метод getAllAccounts не исчез из топа методов, выполняющихся наибольшее количество времени. Следовательно, он выполняется долго сам по себе. 40% его времени выполнения занимает hashSet. Оказывается, что метод hashCode реализовн неправильно, и всегда возвращает 1. Устраним найденные недостатки.</p>
		<h2>Запуск №3</h2>
		<p>CPU: 10-12%</p>
		<p>Память скачет и растет с 25 МБ. Очевидна утечка.</p>
		<table>
			<tr>
				<td>Количество итераций</td>
				<td>1000</td>
				<td>2000</td>
				<td>3000</td>
			</tr>
			<tr>
				<td>Среднее время</td>
				<td>0.11</td>
				<td>0.113</td>
				<td>0.125</td>
			</tr>
		</table>
		<p>Несмотря на то, что в топе методов по времени выполнения до сих пор присутствуют getAllAccounts и getAllUsers, никакой оптимизации я придумать не смог. Перейдем к устранению утечки памяти. Первое, что я заметил, большое количество объектов User. Покопаясь в коде, обнаружил бесполезный список fetched, который постоянно растет, но нигде не используется.</p>
		<h2>Запуск №4</h2>
		<p>CPU: 10-12%</p>
		<p>Память скачет и растет(медленней, чем до этого) с 25 МБ.</p>
		<p>Среднее время выполнения примерно старое.</p>
		<p>Теперь бросается в глаза большое количество java.sql.DriverInfo. Изрядно помучавшись, заметим, что в методах getUserDAO и getAccountDAO при return создается новый объект, а выше в коде созданы 2 статических объекта userDAO и accountDAO.</p>
		<h2>Запуск №5</h2>
		<p>CPU: 10-11%</p>
		<p>Память: около 25 МБ</p>
		<p>Среднее время выполнения примерно, как при запуске 3.</p>
		<p>Как бы я ни старался, никаких оптимизаций привнести больше не смог.</p>
		<h2>Тестирование GC</h2>
		<h3>SerialGC</h3>
		<p>Среднее время: 0.127</p>
		<p>CPU: 10% с редкими всплесками до 20-25%</p>
		<p>Постоянный размер heap - 60 МБ, занимаемый объем редко переваливает за 25 МБ. </p>
		<h3>ParallelGC</h3>
		<p>Среднее время: 0.122</p>
		<p>CPU: 9% с редкими всплесками до 18%</p>
		<p>Постоянный размера heap отсутствует, он постоянно растет, в пике почти 350 МБ. При этом занимаемое пространство скачет со всплесками до 200 МБ. При этом самое лучшее среднее время отклика и самая маленькая загрузка процессора.</p>
		<h3>CMS GC</h3>
		<p>Среднее время: 0.125</p>
		<p>CPU: 10% с достаточно частыми всплесками до 14-15%</p>
		<p>Постоянный размер heap - 60 МБ, занимаемый объем редко переваливает за 25 МБ. Достаточно длительные сборки мусора.</p>
		<h3>G1 GC</h3>
		<p>Среднее время: 0.13</p>
		<p>CPU: 13% нестабильно</p>
		<p>Размер heap стартанул с 60 МБ, упал до 22-23 МБ, а затем резко вырос до 92-93 МБ. Занимаемый объем в короткий начальный период - 40 МБ, затем долгий период в 15-16 МБ, затем около 60 МБ.</p>
		<h3>Итог</h3>
		<p>G1 я бы не стал использовать из-за резких скачков, причину которых я не в состоянии объяснить. Хотя G1 в середине замера имел лучшие показатели по памяти. Parallel GC мне не понравился достаточно долгим ростом занимаемой части хипа. Среди оставшихся CMS имеет лучше показатели по CPU.</p>